### PR TITLE
Implemented broadcast_and_wait block

### DIFF
--- a/src/pystage/core/_events.py
+++ b/src/pystage/core/_events.py
@@ -80,5 +80,6 @@ class _Events(BaseSprite):
 
     def event_broadcastandwait(self, message):
         # waits until all receiver scripts finish. Tricky.
-        pass
+        self.code_manager.current_block.broadcasting = True
+        self.stage.message_broker.broadcast(message)
 

--- a/src/pystage/core/messages.py
+++ b/src/pystage/core/messages.py
@@ -7,10 +7,22 @@ class MessageBroker():
     def __init__(self, stage):
         self.stage = stage
         self._messages = []
+        self.status_checkers = []
 
 
     def broadcast(self, message):
         self._messages.append(message)
+        self.status_checkers.clear()
+        for sprite in self.stage.visible_sprites:
+            sprite.code_manager.process_broadcast(message)
+            self.status_checkers.append(lambda : sprite.code_manager.broadcast_done(message))
+        self.stage.code_manager.process_broadcast(message)
+        self.status_checkers.append(lambda : self.stage.code_manager.broadcast_done(message))
+
+
+    def broadcast_done(self):
+        # check if all sprites and the stage have done their broadcast
+        return all([checker() for checker in self.status_checkers])
 
 
     def get_messages(self):

--- a/src/pystage/core/stage.py
+++ b/src/pystage/core/stage.py
@@ -180,13 +180,6 @@ class CoreStage(
                             sprite.code_manager.process_click()
                             break
 
-            # Handle broadcast messages
-            for message in self.message_broker.get_messages():
-                for sprite in self.sprites:
-                    assert(isinstance(sprite, CoreSprite))
-                    sprite.code_manager.process_broadcast(message)
-            self.message_broker.mark_completed()
-
             self._update(dt)
             self.sprites.update(dt)
             self.bubbles.update()


### PR DESCRIPTION
### Detailed Explanation

Firstly, after discussing with @VictorNorman, we have concluded that by moving the broadcasting handler out of the main game loop, we can reduce the running time.

We have decided to execute blocks that will be called upon receiving a message inside the `broadcast` function. As a result, there's no need to detect the broadcast event in every game frame.

In order to make it wait until broadcasting is done, I added a `broadcasting` attribute to `CodeBlock`. This attribute will be set to `True` when calling the `broadcast_and_wait` function. If the function is broadcasting, the waiting time is simply maintained, as we don't know when it will finish.

When a message is broadcasted, we collect all the functions from the sprites and the stage that will be invoked by the message.

We then check if all the functions' `running` attribute is `False`, which indicates all blocks have finished executing.

Finally, the `broadcasting` attribute is set back to `False`.


### Example test code:

```python
from pystage.en import Stage, Sprite

stage = Stage()
zombie = stage.add_a_sprite()

def doit():
    zombie.broadcast_and_wait("hello")
    zombie.say("broadcast done")


def hello():
    zombie.say("sprite received broadcast")
    zombie.wait(2)

def a():
    stage.wait_seconds(4)

zombie.when_program_starts(doit)
zombie.when_i_receive_message("hello", hello)
# stage.when_i_receive("hello", a)

stage.play()

```