### PR TITLE
Implemented distance_to_sprite block

### DIFF
--- a/src/pystage/convert/code_writer.py
+++ b/src/pystage/convert/code_writer.py
@@ -63,6 +63,7 @@ class CodeWriter():
         self.jinja_environment.filters["global_sound"] = lambda name: self.global_sound(name)
         self.jinja_environment.filters["global_costume"] = lambda name: self.global_costume(name)
         self.jinja_environment.filters["global_backdrop"] = lambda name: self.global_backdrop(name)
+        self.jinja_environment.filters["global_sprite"] = lambda name: self.get_sprite_var(unquoted(name))
         
         logger.debug("CodeWriter created.")
 

--- a/src/pystage/convert/sb3_templates.py
+++ b/src/pystage/convert/sb3_templates.py
@@ -120,6 +120,7 @@ templates = {
         "sound_sounds_menu": "{{SOUND_MENU | global_sound }}",
 
         "sensing_keyoptions": "{{KEY_OPTION}}",
+        "sensing_distancetomenu": "{{DISTANCETOMENU | global_sprite}}",
 
                 }
 

--- a/src/pystage/core/_sensing.py
+++ b/src/pystage/core/_sensing.py
@@ -232,7 +232,9 @@ class _SensingSprite(BaseSprite):
     sensing_distanceto_pointer.value="_mouse_"
 
     def sensing_distanceto_sprite(self, sprite):
-        pass
+        # self is an instance of CoreSprite
+        # sprite is an instance of Sprite
+        return self._pos.distance_to(sprite._core._pos)
     sensing_distanceto_sprite.opcode="sensing_distanceto"
 
 


### PR DESCRIPTION
Used variable for passing a sprite to `distance_to_sprite` function instead of a string, so that we don't need to get the sprite object from a string in runtime.

Currently sprite1 can't access sprite2 because it haven't created yet. It was solved in PR #92, which initialize all sprites ahead. So, should not be a problem.