### PR TITLE
Enable relative loading of assets for pystage-generated .py files.

### DIFF
--- a/src/pystage/core/assets.py
+++ b/src/pystage/core/assets.py
@@ -151,7 +151,13 @@ class Costume():
         self.file = None
         self.name = name
         internal_folder = pkg_resources.resource_filename("pystage", "images/")
-        for folder in ["", "images/", "bilder/", internal_folder]:
+        search_folders = ["", "images/", "bilder/", internal_folder]
+
+        if len(sys.argv[0])>0:
+            file_directory = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), "images/")
+            search_folders.insert(0, file_directory)
+
+        for folder in search_folders:
             for ext in ["", ".bmp", ".png", ".jpg", ".jpeg", ".gif", ".svg"]:
                 if os.path.exists(f"{folder}{name}{ext}"):
                     self.file = f"{folder}{name}{ext}"
@@ -213,7 +219,13 @@ class Sound():
         self.file = None
         self.sound = None
         internal_folder = pkg_resources.resource_filename("pystage", "sounds/")
-        for folder in ["", "sounds/", "klaenge/", internal_folder]:
+        search_folders = ["", "sounds/", "klaenge/", internal_folder]
+
+        if len(sys.argv[0])>0:
+            file_directory = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), "sounds/")
+            search_folders.insert(0, file_directory)
+
+        for folder in search_folders:
             for ext in ["", ".wav", ".ogg", ".mp3"]:
                 if os.path.exists(f"{folder}{name}{ext}"):
                     self.file = f"{folder}{name}{ext}"


### PR DESCRIPTION
Previously, pystage loaded assets from the current directories or the pkg directory. This commit introduces the ability to load assets from any location by dynamically adding search directories relative to the location of the pystage-generated .py file. With this change, pystage-generated .py files can smoothly load assets and run from different directories.

After the merge, errors like this should disappear:
```
ahlongxp@ZacWorkBook sbs % python move6/move.py 
New costume: _1 -> /Users/ahlongxp/coding/pystage/src/pystage/images/zombie_idle.png
New costume: _1_2 -> /Users/ahlongxp/coding/pystage/src/pystage/images/zombie_idle.png
New costume: _2 -> /Users/ahlongxp/coding/pystage/src/pystage/images/zombie_idle.png
Traceback (most recent call last):
  File "/Users/ahlongxp/coding/sbs/move6/move.py", line 18, in <module>
    _1.add_sound('a_bass')
  File "/Users/ahlongxp/coding/pystage/src/pystage/en/sprite.py", line 1752, in add_sound
    return self._core.pystage_addsound(name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ahlongxp/coding/pystage/src/pystage/core/_sound.py", line 23, in pystage_addsound
    self.sound_manager.add_sound(name)
  File "/Users/ahlongxp/coding/pystage/src/pystage/core/assets.py", line 196, in add_sound
    sound = Sound(self, name)
            ^^^^^^^^^^^^^^^^^
  File "/Users/ahlongxp/coding/pystage/src/pystage/core/assets.py", line 223, in __init__
    if self.file.endswith(".mp3"):
       ^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'endswith'
```