### PR TITLE
Add support for incomplete conditionals

### DIFF
--- a/src/pystage/convert/code_writer.py
+++ b/src/pystage/convert/code_writer.py
@@ -64,6 +64,7 @@ class CodeWriter():
         self.jinja_environment.filters["global_costume"] = lambda name: self.global_costume(name)
         self.jinja_environment.filters["global_backdrop"] = lambda name: self.global_backdrop(name)
         self.jinja_environment.filters["global_sprite"] = lambda name: self.get_sprite_var(unquoted(name))
+        self.jinja_environment.filters["if_missing"] = lambda x, extra: x or extra
         
         logger.debug("CodeWriter created.")
 

--- a/src/pystage/convert/sb3_templates.py
+++ b/src/pystage/convert/sb3_templates.py
@@ -99,7 +99,7 @@ templates = {
                 ''',
 
         "operator_add": "({{NUM1}} + {{NUM2}})",
-        "operator_and": "({{OPERAND1}} and {{OPERAND2}})",
+        "operator_and": "({{OPERAND1}} and {{OPERAND2 | if_missing(True)}})",
         "operator_contains": "({{STRING2}} in {{STRING1}})",
         "operator_divide": "({{NUM1}} / {{NUM2}})",
         "operator_equals": "({{OPERAND1}} == {{OPERAND2}})",
@@ -111,7 +111,7 @@ templates = {
         "operator_mod": "({{NUM1}} % {{NUM2}})",
         "operator_multiply": "({{NUM1}} * {{NUM2}})",
         "operator_not": "not ({{OPERAND}})",
-        "operator_or": "({{OPERAND1}} or {{OPERAND2}})",
+        "operator_or": "({{OPERAND1}} or {{OPERAND2 | if_missing(False)}})",
         "operator_round": "round({{NUM}})",
         "operator_subtract": "({{NUM1}} - {{NUM2}})",
 


### PR DESCRIPTION
In Scratch you can have an and/or block with no second operand, and Scratch just ignores it. As an example, see https://scratch.mit.edu/projects/1009801853/.

Before this produced the code:

```
        if ((self.get_variable("Speed") < 0) and (self.touching_color((183, 137, 55)) or )):
```

Which is a syntax error. Afterwards it produces:

```
        if ((self.get_variable("Speed") < 0) and (self.touching_color((183, 137, 55)) or False)):
```